### PR TITLE
Fix build warnings with feed.xml

### DIFF
--- a/feed.xml
+++ b/feed.xml
@@ -1,5 +1,5 @@
 ---
-layout: none
+layout: null
 ---
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">


### PR DESCRIPTION
Fixed layout for feed to prevent build warnings (see: https://github.com/jekyll/jekyll/issues/2712)